### PR TITLE
Convert gitechccoe/pipelines/aws to GitHub Actions

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -1,0 +1,8 @@
+name: gitechccoe/pipelines/aws
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: true


### PR DESCRIPTION
Pipeline migrated from [GitLab](https://gitccoe.aws.amdocs.cloud/gitechccoe/pipelines/aws) :tada: